### PR TITLE
Fix test warning: `has_git()` is obsolete

### DIFF
--- a/t/20-init.t
+++ b/t/20-init.t
@@ -2,10 +2,11 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Git;
+use Test::Requires::Git;
 use File::Temp qw( tempdir );
 use Git::CPAN::Hook;
 
-has_git('1.5.1');
+test_requires_git('1.5.1');
 
 plan tests => my $tests;
 

--- a/t/21-commit.t
+++ b/t/21-commit.t
@@ -1,14 +1,14 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Git;
+use Test::Requires::Git;
 use File::Temp qw( tempdir );
 use File::Path;
 use File::Spec;
 use File::Basename;
 use Git::CPAN::Hook;
 
-has_git('1.5.1');
+test_requires_git('1.5.1');
 
 # a simple file installer
 sub install_file {


### PR DESCRIPTION
This fixes issue #1.

*[[Assigned by [pullrequest.club](https://pullrequest.club)]]*